### PR TITLE
add use cases & keep in draft without receiver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,17 @@
         }
     ],
     "autoload": {
+        "classmap": [
+          "vendor/laravel/laravel/tests/TestCase.php"
+        ],
         "psr-4": {
             "Inani\\Messager\\": "src/"
         }
     },
     "minimum-stability": "dev",
     "require": {
+        "phpunit/phpunit" : "5.*",
+        "fzaninotto/faker": "~1.4",
         "illuminate/support": "~5"
     }
 }

--- a/src/Helpers/MessageHandler.php
+++ b/src/Helpers/MessageHandler.php
@@ -14,20 +14,26 @@ class MessageHandler {
     const READ = 2;
 
     /**
-     * Get An array and return two objects
+     * Get an array and return two objects
      *
      * @param array $attribute
      * @return array
      */
     public  static function create(array $attribute)
     {
-        return [
-            new Message(
-                [
-                    'content' => $attribute['content'],
-                ]
-            ),
-            User::findOrFail($attribute['to_id'])
-        ];
+        $message = null;
+        $user = null;
+
+        if(array_key_exists('content', $attribute))
+        {
+            $message = new Message(['content' => $attribute['content']]);
+        }
+
+        if(array_key_exists('to_id', $attribute))
+        {
+            $user = User::find($attribute['to_id']);
+        }
+
+        return [$message , $user];
     }
 }

--- a/src/Helpers/QueryMessages.php
+++ b/src/Helpers/QueryMessages.php
@@ -79,6 +79,7 @@ trait QueryMessages
 
     /**
      * Read the selected Messages
+     *
      * @param $query
      * @return mixed
      */

--- a/src/migrations/2017_01_02_201510_create_messages_table.php
+++ b/src/migrations/2017_01_02_201510_create_messages_table.php
@@ -15,7 +15,7 @@ class CreateMessagesTable extends Migration
         Schema::create('messages', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('from_id')->unsigned();
-            $table->integer('to_id')->unsigned();
+            $table->integer('to_id')->unsigned()->nullable();
             $table->text('content');
             $table->integer('state')->defaul(0);
             $table->timestamps();


### PR DESCRIPTION
 Add the posibility to keep in draft without specifying the receiver.
Just need to fix the possibility to send a message without receiver.